### PR TITLE
Append extension if it is not included in title

### DIFF
--- a/content.js
+++ b/content.js
@@ -36,9 +36,15 @@ if (matchPattern.test(url)) {
 function run() {
     let videoDiv = document.getElementById('video_0');
     let videoUrl = videoDiv.firstElementChild.getAttribute('src');
+    let fileName = new URL(videoUrl).pathname.split("/").slice(-1)[0];
+    let fileExtension = "." + fileName.split(".").slice(-1)[0];
+    let title = document.title;
+    if (!title.endsWith(fileExtension)) {
+        title += fileExtension;
+    }
     chrome.runtime.sendMessage({
         'name': 'recording',
         'videoUrl': videoUrl,
-        'title': document.title
+        'title': title
     });
 }


### PR DESCRIPTION
Fixes #5.

This may be too much of a workaround, but instead of matching a regex of possible movie file extensions and then guessing which of these to use when the title doesn't match, I instead get the path of the video url and extract its filename. This of course assumes that every video url actually ends with a filename, but in my preliminary tests I had no problems with that. Maybe you could test this for more courses.